### PR TITLE
The original download location is no longer available

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-packer_pkg: packer_0.8.6_linux_amd64.zip
-packer_version_str: "Packer v0.8.6"
+packer_base_url: https://releases.hashicorp.com/packer/0.11.0/
+packer_pkg: packer_0.11.0_linux_amd64.zip
+packer_version_str: "Packer v0.11.0"
 packer_plugins: {}
 packer_plugins_force_install: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     - /var/cache/packer
 
 - name: fetch packer
-  get_url: url=https://dl.bintray.com/mitchellh/packer/{{ packer_pkg }}
+  get_url: url={{ packer_base_url }}{{ packer_pkg }}
            dest=/var/cache/packer/{{ packer_pkg }}
   when: packer_install_needed
 


### PR DESCRIPTION
I updated the defaults to have a definable URL so that when the location changes we do not need to update the role, just a variable in the playbook / group_vars